### PR TITLE
Fix some minor bugs in the codereview ext.

### DIFF
--- a/lib/code-review.js
+++ b/lib/code-review.js
@@ -16,7 +16,7 @@ CodeReview.prototype.commands = {
 };
 
 CodeReview.prototype.add = function (request) {
-	coder = request.from;
+	var coder = request.from;
 	if (this.pending.indexOf(coder) == -1) {
 		this.pending.push(coder);
 		return this.show();
@@ -26,6 +26,7 @@ CodeReview.prototype.add = function (request) {
 }
 
 CodeReview.prototype.remove = function (request) {
+	var coder = request.from;
 	if (this.pending.indexOf(coder) > -1){
 		this.pending.splice(this.pending.indexOf(coder), 1);
 		return this.show();


### PR DESCRIPTION
1. 'coder' should be a local, not a global.
2. 'nohaz' should use the currently-speaking user, not the last person to say !haz.
